### PR TITLE
Update to match change in the GVGAI framework

### DIFF
--- a/Single-Player/src/MaastCTS2/controller/MctsController.java
+++ b/Single-Player/src/MaastCTS2/controller/MctsController.java
@@ -725,7 +725,7 @@ public class MctsController implements IController {
 		
 		long maxDurationSafetyCheckRound = 0L;
 		for(int safetyCheckRound = 0; safetyCheckRound < MAX_NUM_SAFETY_CHECKS; ++safetyCheckRound){
-			ElapsedCpuTimer roundTimer = new ElapsedCpuTimer(CompetitionParameters.TIMER_TYPE);
+			ElapsedCpuTimer roundTimer = new ElapsedCpuTimer();
 			for(int actionIdx = 0; actionIdx < numRootActions; ++actionIdx){				
 				StateObservation successor = rootStateObs.copy();
 				successor.advance(availableActions.get(actionIdx));
@@ -819,7 +819,7 @@ public class MctsController implements IController {
 
 		long maxDurationSafetyCheckRound = 0L;
 		for(int safetyCheckRound = 0; safetyCheckRound < MAX_NUM_SAFETY_CHECKS; ++safetyCheckRound){
-			ElapsedCpuTimer roundTimer = new ElapsedCpuTimer(CompetitionParameters.TIMER_TYPE);
+			ElapsedCpuTimer roundTimer = new ElapsedCpuTimer();
 			for(int actionIdx = 0; actionIdx < numActions; ++actionIdx){				
 				StateObservation successor = state.copy();
 				successor.advance(children.get(actionIdx).getActionFromParent());	// TODO also use these states to update knowledge base?

--- a/Two-Player/src/MaastCTS2/controller/MctsController.java
+++ b/Two-Player/src/MaastCTS2/controller/MctsController.java
@@ -549,7 +549,7 @@ public class MctsController implements IController {
 		
 		long maxDurationSafetyCheckRound = 0L;
 		for(int safetyCheckRound = 0; safetyCheckRound < MAX_NUM_SAFETY_CHECKS; ++safetyCheckRound){
-			ElapsedCpuTimer roundTimer = new ElapsedCpuTimer(CompetitionParameters.TIMER_TYPE);
+			ElapsedCpuTimer roundTimer = new ElapsedCpuTimer();
 			for(int actionIdx = 0; actionIdx < numRootActions; ++actionIdx){				
 				StateObservationMulti successor = rootStateObs.copy();
 				successor.advance(Globals.generateActionArray(availableActions.get(actionIdx), successor, null, null, 0.0, root));
@@ -644,7 +644,7 @@ public class MctsController implements IController {
 
 		long maxDurationSafetyCheckRound = 0L;
 		for(int safetyCheckRound = 0; safetyCheckRound < MAX_NUM_SAFETY_CHECKS; ++safetyCheckRound){
-			ElapsedCpuTimer roundTimer = new ElapsedCpuTimer(CompetitionParameters.TIMER_TYPE);
+			ElapsedCpuTimer roundTimer = new ElapsedCpuTimer();
 			for(int actionIdx = 0; actionIdx < numActions; ++actionIdx){				
 				StateObservationMulti successor = state.copy();
 				successor.advance(Globals.generateActionArray(children.get(actionIdx).getActionFromParent(), 


### PR DESCRIPTION
Since the last change of MaastCTS2, the GVGAI framework has changed, which leads to an error with the creation of `new ElapsedCpuTimer()` objects, as it is no longer necessary to specify parameters to the constructor.

Moreover, I have checked by comparing the GVGAI framework's code from the 2016 competition with the current state, and I am pretty sure that the standard constructor (with no parameters) in the current state of the framework does the same as what the 2016 code did when specifying `CompetitionParameters.TIMER_TYPE`.

In short, this should adapt the MaastCTS2 (both single-player and two-player) agents to the current state of the framework :D